### PR TITLE
[yang]: adding Buffer pool enum type both for sonic chassis (#18956)

### DIFF
--- a/src/sonic-yang-models/tests/yang_model_tests/tests/buffer_pool.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/buffer_pool.json
@@ -5,6 +5,9 @@
     "BUFFER_POOL_CORRECT_TYPE_EGRESS_VALUE": {
         "desc": "BUFFER_POOL_CORRECT_TYPE_EGRESS_VALUE no failure."
     },
+    "BUFFER_POOL_CORRECT_TYPE_BOTH_VALUE": {
+        "desc": "BUFFER_POOL_CORRECT_TYPE_BOTH_VALUE no failure."
+    },
     "BUFFER_POOL_WRONG_TYPE_VALUE": {
         "desc": "BUFFER_POOL_WRONG_TYPE_VALUE pattern failure.",
         "eStr": "wrong"

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/buffer_pool.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/buffer_pool.json
@@ -27,6 +27,20 @@
             }
         }
     },
+    "BUFFER_POOL_CORRECT_TYPE_BOTH_VALUE": {
+        "sonic-buffer-pool:sonic-buffer-pool": {
+            "sonic-buffer-pool:BUFFER_POOL": {
+                "BUFFER_POOL_LIST": [
+                {
+                    "name": "Ethernet4",
+                    "mode": "static",
+                    "size": "12766208",
+                    "type": "both"
+                }
+                ]
+            }
+        }
+    },
     "BUFFER_POOL_WRONG_TYPE_VALUE": {
         "sonic-buffer-pool:sonic-buffer-pool": {
             "sonic-buffer-pool:BUFFER_POOL": {

--- a/src/sonic-yang-models/yang-models/sonic-buffer-pool.yang
+++ b/src/sonic-yang-models/yang-models/sonic-buffer-pool.yang
@@ -33,6 +33,7 @@ module sonic-buffer-pool {
                     type enumeration {
                         enum ingress;
                         enum egress;
+                        enum both;
                     }
                     description "Buffer Pool Type";
                 }


### PR DESCRIPTION
This is to back port the changes from : (https://github.com/sonic-net/sonic-buildimage/pull/18956)
to the MSFT repo 202205 branch.

For details, please refer to the original PR.
