### PR TITLE
[Chassis][Voq]Update sonic-buffer-queue and sonic-queue for Voq Chass…

### DIFF
--- a/src/sonic-yang-models/tests/files/sample_config_db.json
+++ b/src/sonic-yang-models/tests/files/sample_config_db.json
@@ -315,7 +315,6 @@
                 "region": "usfoo",
                 "asic_name": "Asic0",
                 "switch_id": "2",
-                "switch_type": "voq",
                 "max_cores": "8",
                 "sub_role": "FrontEnd",
                 "dhcp_server": "disabled",

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/buffer_queue.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/buffer_queue.json
@@ -13,5 +13,8 @@
     "BUFFER_QUEUE_WRONG_PORT_VALUE": {
         "desc": "BUFFER_QUEUE_WRONG_PORT_VALUE pattern failure",
         "eStr": "wrong"
+    },
+    "VOQ_BUFFER_QUEUE_CONFIG": {
+        "desc": "VOQ_BUFFER_QUEUE_CONFIG has no failure"
     }
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests/qos.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests/qos.json
@@ -85,5 +85,8 @@
     "QUEUE_WRED_NOT_EXIST": {
         "desc": "Referring non-existing WRED table.",
         "eStrKey" : "LeafRef"
+    },
+    "VOQ_QUEUE_CONFIG": {
+        "desc": "Attach scheduler and wred profiles to VOQ."
     }
 }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/buffer_queue.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/buffer_queue.json
@@ -3,51 +3,51 @@
         "sonic-port:sonic-port": {
             "sonic-port:PORT": {
                 "PORT_LIST": [
-                {
-                    "admin_status": "up",
-                    "alias": "eth0",
-                    "description": "Ethernet0",
-                    "lanes": "65",
-                    "mtu": "9000",
-                    "name": "Ethernet4",
-                    "tpid": "0x8100",
-                    "speed": "25000"
-                }
+                    {
+                        "admin_status": "up",
+                        "alias": "eth0",
+                        "description": "Ethernet0",
+                        "lanes": "65",
+                        "mtu": "9000",
+                        "name": "Ethernet4",
+                        "tpid": "0x8100",
+                        "speed": "25000"
+                    }
                 ]
             }
         },
         "sonic-buffer-pool:sonic-buffer-pool": {
             "sonic-buffer-pool:BUFFER_POOL": {
                 "BUFFER_POOL_LIST": [
-                {
-                    "name": "egress_lossless_pool",
-                    "mode": "static",
-                    "size": "12766208",
-                    "type": "ingress"
-                }
+                    {
+                        "name": "egress_lossless_pool",
+                        "mode": "static",
+                        "size": "12766208",
+                        "type": "ingress"
+                    }
                 ]
             }
         },
         "sonic-buffer-profile:sonic-buffer-profile": {
             "sonic-buffer-profile:BUFFER_PROFILE": {
                 "BUFFER_PROFILE_LIST": [
-                {
-                    "name": "lossless_buffer_profile",
-                    "size": 1518,
-                    "dynamic_th": "2",
-                    "pool": "egress_lossless_pool"
-                }
+                    {
+                        "name": "lossless_buffer_profile",
+                        "size": 1518,
+                        "dynamic_th": "2",
+                        "pool": "egress_lossless_pool"
+                    }
                 ]
             }
         },
         "sonic-buffer-queue:sonic-buffer-queue": {
             "sonic-buffer-queue:BUFFER_QUEUE": {
                 "BUFFER_QUEUE_LIST": [
-                {
-                    "port": "Ethernet4",
-                    "qindex": "15",
-                    "profile": "lossless_buffer_profile"
-                }
+                    {
+                        "port": "Ethernet4",
+                        "qindex": "15",
+                        "profile": "lossless_buffer_profile"
+                    }
                 ]
             }
         }
@@ -56,50 +56,50 @@
         "sonic-port:sonic-port": {
             "sonic-port:PORT": {
                 "PORT_LIST": [
-                {
-                    "admin_status": "up",
-                    "alias": "eth0",
-                    "description": "Ethernet0",
-                    "lanes": "65",
-                    "mtu": "9000",
-                    "name": "Ethernet4",
-                    "tpid": "0x8100",
-                    "speed": "25000"
-                }
+                    {
+                        "admin_status": "up",
+                        "alias": "eth0",
+                        "description": "Ethernet0",
+                        "lanes": "65",
+                        "mtu": "9000",
+                        "name": "Ethernet4",
+                        "tpid": "0x8100",
+                        "speed": "25000"
+                    }
                 ]
             }
         },
         "sonic-buffer-pool:sonic-buffer-pool": {
             "sonic-buffer-pool:BUFFER_POOL": {
                 "BUFFER_POOL_LIST": [
-                {
-                    "name": "egress_lossless_pool",
-                    "mode": "static",
-                    "size": "12766208",
-                    "type": "ingress"
-                }
+                    {
+                        "name": "egress_lossless_pool",
+                        "mode": "static",
+                        "size": "12766208",
+                        "type": "ingress"
+                    }
                 ]
             }
         },
         "sonic-buffer-profile:sonic-buffer-profile": {
             "sonic-buffer-profile:BUFFER_PROFILE": {
                 "BUFFER_PROFILE_LIST": [
-                {
-                    "name": "lossless_buffer_profile",
-                    "size": "1518",
-                    "pool": "egress_lossless_pool"
-                }
+                    {
+                        "name": "lossless_buffer_profile",
+                        "size": "1518",
+                        "pool": "egress_lossless_pool"
+                    }
                 ]
             }
         },
         "sonic-buffer-queue:sonic-buffer-queue": {
             "sonic-buffer-queue:BUFFER_QUEUE": {
                 "BUFFER_QUEUE_LIST": [
-                {
-                    "port": "Ethernet4",
-                    "qindex": "3",
-                    "profile": "wrong"
-                }
+                    {
+                        "port": "Ethernet4",
+                        "qindex": "3",
+                        "profile": "wrong"
+                    }
                 ]
             }
         }
@@ -108,50 +108,50 @@
         "sonic-port:sonic-port": {
             "sonic-port:PORT": {
                 "PORT_LIST": [
-                {
-                    "admin_status": "up",
-                    "alias": "eth0",
-                    "description": "Ethernet0",
-                    "lanes": "65",
-                    "mtu": "9000",
-                    "name": "Ethernet4",
-                    "tpid": "0x8100",
-                    "speed": "25000"
-                }
+                    {
+                        "admin_status": "up",
+                        "alias": "eth0",
+                        "description": "Ethernet0",
+                        "lanes": "65",
+                        "mtu": "9000",
+                        "name": "Ethernet4",
+                        "tpid": "0x8100",
+                        "speed": "25000"
+                    }
                 ]
             }
         },
         "sonic-buffer-pool:sonic-buffer-pool": {
             "sonic-buffer-pool:BUFFER_POOL": {
                 "BUFFER_POOL_LIST": [
-                {
-                    "name": "egress_lossless_pool",
-                    "mode": "static",
-                    "size": "12766208",
-                    "type": "ingress"
-                }
+                    {
+                        "name": "egress_lossless_pool",
+                        "mode": "static",
+                        "size": "12766208",
+                        "type": "ingress"
+                    }
                 ]
             }
         },
         "sonic-buffer-profile:sonic-buffer-profile": {
             "sonic-buffer-profile:BUFFER_PROFILE": {
                 "BUFFER_PROFILE_LIST": [
-                {
-                    "name": "lossless_buffer_profile",
-                    "size": "1518",
-                    "pool": "egress_lossless_pool"
-                }
+                    {
+                        "name": "lossless_buffer_profile",
+                        "size": "1518",
+                        "pool": "egress_lossless_pool"
+                    }
                 ]
             }
         },
         "sonic-buffer-queue:sonic-buffer-queue": {
             "sonic-buffer-queue:BUFFER_QUEUE": {
                 "BUFFER_QUEUE_LIST": [
-                {
-                    "port": "Ethernet4",
-                    "qindex": "16",
-                    "profile": "lossless_buffer_profile"
-                }
+                    {
+                        "port": "Ethernet4",
+                        "qindex": "16",
+                        "profile": "lossless_buffer_profile"
+                    }
                 ]
             }
         }
@@ -160,50 +160,96 @@
         "sonic-port:sonic-port": {
             "sonic-port:PORT": {
                 "PORT_LIST": [
-                {
-                    "admin_status": "up",
-                    "alias": "eth0",
-                    "description": "Ethernet0",
-                    "lanes": "65",
-                    "mtu": "9000",
-                    "name": "Ethernet4",
-                    "tpid": "0x8100",
-                    "speed": "25000"
-                }
+                    {
+                        "admin_status": "up",
+                        "alias": "eth0",
+                        "description": "Ethernet0",
+                        "lanes": "65",
+                        "mtu": "9000",
+                        "name": "Ethernet4",
+                        "tpid": "0x8100",
+                        "speed": "25000"
+                    }
                 ]
             }
         },
         "sonic-buffer-pool:sonic-buffer-pool": {
             "sonic-buffer-pool:BUFFER_POOL": {
                 "BUFFER_POOL_LIST": [
-                {
-                    "name": "egress_lossless_pool",
-                    "mode": "static",
-                    "size": "12766208",
-                    "type": "ingress"
-                }
+                    {
+                        "name": "egress_lossless_pool",
+                        "mode": "static",
+                        "size": "12766208",
+                        "type": "ingress"
+                    }
                 ]
             }
         },
         "sonic-buffer-profile:sonic-buffer-profile": {
             "sonic-buffer-profile:BUFFER_PROFILE": {
                 "BUFFER_PROFILE_LIST": [
-                {
-                    "name": "lossless_buffer_profile",
-                    "size": "1518",
-                    "pool": "egress_lossless_pool"
-                }
+                    {
+                        "name": "lossless_buffer_profile",
+                        "size": "1518",
+                        "pool": "egress_lossless_pool"
+                    }
                 ]
             }
         },
         "sonic-buffer-queue:sonic-buffer-queue": {
             "sonic-buffer-queue:BUFFER_QUEUE": {
                 "BUFFER_QUEUE_LIST": [
-                {
-                    "port": "wrong",
-                    "qindex": "4",
-                    "profile": "lossless_buffer_profile"
+                    {
+                        "port": "wrong",
+                        "qindex": "4",
+                        "profile": "lossless_buffer_profile"
+                    }
+                ]
+            }
+        }
+    },
+    "VOQ_BUFFER_QUEUE_CONFIG": {
+        "sonic-device_metadata:sonic-device_metadata": {
+            "sonic-device_metadata:DEVICE_METADATA": {
+                "sonic-device_metadata:localhost": {
+                    "switch_type": "voq"
                 }
+            }
+        },
+        "sonic-buffer-pool:sonic-buffer-pool": {
+            "sonic-buffer-pool:BUFFER_POOL": {
+                "BUFFER_POOL_LIST": [
+                    {
+                        "name": "egress_lossless_pool",
+                        "mode": "static",
+                        "size": "12766208",
+                        "type": "ingress"
+                    }
+                ]
+            }
+        },
+        "sonic-buffer-profile:sonic-buffer-profile": {
+            "sonic-buffer-profile:BUFFER_PROFILE": {
+                "BUFFER_PROFILE_LIST": [
+                    {
+                        "name": "lossless_buffer_profile",
+                        "size": 1518,
+                        "dynamic_th": "2",
+                        "pool": "egress_lossless_pool"
+                    }
+                ]
+            }
+        },
+        "sonic-buffer-queue:sonic-buffer-queue": {
+            "sonic-buffer-queue:BUFFER_QUEUE": {
+                "VOQ_BUFFER_QUEUE_LIST": [
+                    {
+                        "hostname": "lc1",
+                        "asic_name": "asic0",
+                        "port": "Ethernet4",
+                        "qindex": "15",
+                        "profile": "lossless_buffer_profile"
+                    }
                 ]
             }
         }

--- a/src/sonic-yang-models/tests/yang_model_tests/tests_config/qos.json
+++ b/src/sonic-yang-models/tests/yang_model_tests/tests_config/qos.json
@@ -511,5 +511,68 @@
                 ]
             }
         }
+    },
+    "VOQ_QUEUE_CONFIG": {
+        "sonic-device_metadata:sonic-device_metadata": {
+            "sonic-device_metadata:DEVICE_METADATA": {
+                "sonic-device_metadata:localhost": {
+                    "switch_type": "voq"
+                }
+            }
+        },
+        "sonic-scheduler:sonic-scheduler":{
+            "sonic-scheduler:SCHEDULER": {
+                "SCHEDULER_LIST": [
+                {
+                    "name":"Test@0",
+                    "cbs": 256,
+                    "cir": 1250000,
+                    "meter_type": "bytes",
+                    "pbs": 1024,
+                    "pir": 25000000,
+                    "type": "DWRR",
+                    "weight": 10
+                }
+                ]
+            }
+        },
+        "sonic-wred-profile:sonic-wred-profile":{
+            "sonic-wred-profile:WRED_PROFILE": {
+                "WRED_PROFILE_LIST": [
+                {
+                    "name":"Wred1",
+                    "yellow_min_threshold": 2048,
+                    "green_min_threshold": 4096,
+                    "red_min_threshold": 1024,
+                    "yellow_max_threshold": 4096,
+                    "green_max_threshold": 8192,
+                    "red_max_threshold": 2048,
+                    "ecn": "ecn_none",
+                    "wred_green_enable": true,
+                    "wred_yellow_enable": true,
+                    "wred_red_enable": true,
+                    "yellow_drop_probability": 50,
+                    "green_drop_probability": 25,
+                    "red_drop_probability": 100
+                }
+                ]
+            }
+        },
+
+        "sonic-queue:sonic-queue": {
+            "sonic-queue:QUEUE": {
+                "VOQ_QUEUE_LIST": [
+                {
+                    "hostname": "lc1",
+                    "asic_name": "asic0",
+                    "ifname": "Ethernet0",
+                    "qindex": "0",
+                    "scheduler": "Test@0",
+                    "wred_profile": "Wred1"
+                }
+                ]
+            }
+        }
     }
+
 }

--- a/src/sonic-yang-models/yang-models/sonic-buffer-queue.yang
+++ b/src/sonic-yang-models/yang-models/sonic-buffer-queue.yang
@@ -14,6 +14,14 @@ module sonic-buffer-queue {
         prefix bpf;
     }
 
+    import sonic-device_metadata {
+        prefix sdm;
+    }
+
+    import sonic-types {
+        prefix stypes;
+    }
+
     organization
         "SONiC";
 
@@ -34,12 +42,59 @@ module sonic-buffer-queue {
         container BUFFER_QUEUE {
 
             list BUFFER_QUEUE_LIST {
+                when "not(/sdm:sonic-device_metadata/sdm:DEVICE_METADATA/sdm:localhost/sdm:switch_type) or
+                    (/sdm:sonic-device_metadata/sdm:DEVICE_METADATA/sdm:localhost/sdm:switch_type!='voq')";
+
                 key "port qindex";
 
                 leaf port {
                     type leafref {
                         path "/prt:sonic-port/prt:PORT/prt:PORT_LIST/prt:name";
                     }
+                }
+
+                leaf qindex {
+                    type string {
+                        pattern "(1[0-5]|[0-9])((-)(1[0-5]|[0-9]))?"{
+                            error-message "Invalid Q-index";
+                            error-app-tag qindex-invalid;
+                        }
+                    }
+                    description "Egress Queue Index for a port";
+                }
+
+                leaf profile {
+                    default 0;
+                    type leafref {
+                        path "/bpf:sonic-buffer-profile/bpf:BUFFER_PROFILE/bpf:BUFFER_PROFILE_LIST/bpf:name";
+                    }
+                    description "Buffer Profile associated with Priority Queue for a port";
+                }
+
+            }
+            list VOQ_BUFFER_QUEUE_LIST {
+                when "boolean(/sdm:sonic-device_metadata/sdm:DEVICE_METADATA/sdm:localhost/sdm:switch_type) and
+                    (/sdm:sonic-device_metadata/sdm:DEVICE_METADATA/sdm:localhost/sdm:switch_type='voq')";
+
+                key "hostname asic_name port qindex";
+
+
+                leaf hostname {
+                    type stypes:hostname;
+                }
+
+                leaf asic_name {
+                    type string {
+                        pattern "[Aa]sic[0-4]";
+                    }
+                }
+
+                leaf port {
+                    type string {
+                        length 1..128;
+                    }
+
+                    description "port name.";
                 }
 
                 leaf qindex {

--- a/src/sonic-yang-models/yang-models/sonic-queue.yang
+++ b/src/sonic-yang-models/yang-models/sonic-queue.yang
@@ -22,6 +22,14 @@ module sonic-queue {
         prefix wrd;
     }
 
+    import sonic-device_metadata {
+        prefix sdm;
+    }
+
+    import sonic-types {
+        prefix stypes;
+    }
+
     organization
         "SONiC";
 
@@ -43,10 +51,12 @@ module sonic-queue {
             description "QUEUE part of config_db.json";
             
             list QUEUE_LIST {
+                when "not(/sdm:sonic-device_metadata/sdm:DEVICE_METADATA/sdm:localhost/sdm:switch_type) or
+                    (/sdm:sonic-device_metadata/sdm:DEVICE_METADATA/sdm:localhost/sdm:switch_type!='voq')";
 
                 key "ifname qindex";
 
-    //          sonic-ext:key-pattern "QUEUE|{ifname}|{qindex}"; //special pattern used for extracting keys from redis-key and populate the yang instance
+//         sonic-ext:key-pattern "QUEUE|{ifname}|{qindex}"; //special pattern used for extracting keys from redis-key and populate the yang instance
                                                                  // Total list instances = number(key1) * number(key2) * number(key3)
 
                 leaf ifname {
@@ -83,6 +93,54 @@ module sonic-queue {
                     description "Wred profile for queue.";
                 }
             }
+
+            list VOQ_QUEUE_LIST {
+                when "boolean(/sdm:sonic-device_metadata/sdm:DEVICE_METADATA/sdm:localhost/sdm:switch_type) and
+                    (/sdm:sonic-device_metadata/sdm:DEVICE_METADATA/sdm:localhost/sdm:switch_type='voq')";
+                key "hostname asic_name ifname qindex";
+
+
+                leaf hostname {
+                    type stypes:hostname;
+                }
+
+                leaf asic_name {
+                    type string {
+                        pattern "[Aa]sic[0-4]";
+                    }
+                }
+
+                leaf ifname {
+                    type string {
+                        length 1..128;
+                    }
+
+                    description "Interface name.";
+                }
+                // qindex format is (X) | (X-Y). X is start and Y is end index.
+                // X and Y value depends on platform, example for physical ports 0-7 and
+                // for CPU port 0-48. Example qindex is 3-4
+                leaf qindex {
+                  //  sonic-ext:custom-validation ValidateQindexPattern;
+                    type string;
+                    description "Queue index on the interface.";
+                }
+
+                leaf scheduler {
+                    type leafref {
+                        path "/sch:sonic-scheduler/sch:SCHEDULER/sch:SCHEDULER_LIST/sch:name"; //Reference to SCHEDULER table
+                    }
+                    description "Scheduler for queue.";
+                }
+
+                leaf wred_profile {
+                    type leafref {
+                        path "/wrd:sonic-wred-profile/wrd:WRED_PROFILE/wrd:WRED_PROFILE_LIST/wrd:name"; // Reference to WRED_PROFILE table
+                    }
+                    description "Wred profile for queue.";
+                }
+            }
         }
+
     }
 }


### PR DESCRIPTION
…is (#18875)

Why I did it

The configuration for QUEUE and BUFFER_QUEUE differs between a VOQ device and a Non-VOQ devices. For the Voq device:
The queue and buffer queue is applied on the system port. The system port is a representation of every port in a chassis, the key for systemport consists of Linecard Name , Asic Name and portname On a Non voq device:
the queue and buffer queue configuration is applied on the front panel port.

Due to this differences the yang models sonic-queue.yang and sonic-buffer-queue.yang does not work for Voq devices This is address in this PR

Microsoft ADO (27252773 and 27252696):

How I did it
Update the yang model to have different CONFIG_LIST with different keys based on the following condition

when the switch_type is not present or switch_type is not voq, the yang LIST will have key of port and queue_index when the switch_type is present and switch_type is voqhe yang LIST will have key of Linecard name, asi name, port and queue_index How to verify it
UT and incremental config push on chassis

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

