### PR TITLE
Updated MMU settings for ingress lossy profile Nokia and Arista chass…

### DIFF
--- a/device/arista/x86_64-arista_7800r3_48cq2_lc/Arista-7800R3-48CQ2-C48/buffers_defaults_t2.j2
+++ b/device/arista/x86_64-arista_7800r3_48cq2_lc/Arista-7800R3-48CQ2-C48/buffers_defaults_t2.j2
@@ -30,7 +30,7 @@
             "pool":"ingress_lossless_pool",
             "size":"0",
 	    "xon_offset": "0",
-            "dynamic_th":"-6"
+            "dynamic_th":"0"
         },
         "egress_lossless_profile": {
             "pool":"ingress_lossless_pool",

--- a/device/arista/x86_64-arista_7800r3_48cqm2_lc/Arista-7800R3-48CQM2-C48/buffers_defaults_t2.j2
+++ b/device/arista/x86_64-arista_7800r3_48cqm2_lc/Arista-7800R3-48CQM2-C48/buffers_defaults_t2.j2
@@ -30,7 +30,7 @@
             "pool":"ingress_lossless_pool",
             "size":"0",
 	    "xon_offset": "0",
-            "dynamic_th":"-6"
+            "dynamic_th":"0"
         },
         "egress_lossless_profile": {
             "pool":"ingress_lossless_pool",

--- a/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C36/0/buffers_defaults_t2.j2
+++ b/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C36/0/buffers_defaults_t2.j2
@@ -30,7 +30,7 @@
             "pool":"ingress_lossless_pool",
             "size":"0",
 	    "xon_offset": "0",
-            "dynamic_th":"-6"
+            "dynamic_th":"0"
         },
         "egress_lossless_profile": {
             "pool":"ingress_lossless_pool",

--- a/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C36/1/buffers_defaults_t2.j2
+++ b/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C36/1/buffers_defaults_t2.j2
@@ -30,7 +30,7 @@
             "pool":"ingress_lossless_pool",
             "size":"0",
 	    "xon_offset": "0",
-            "dynamic_th":"-6"
+            "dynamic_th":"0"
         },
         "egress_lossless_profile": {
             "pool":"ingress_lossless_pool",

--- a/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C72/0/buffers_defaults_t2.j2
+++ b/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C72/0/buffers_defaults_t2.j2
@@ -30,7 +30,7 @@
             "pool":"ingress_lossless_pool",
             "size":"0   ",
 	    "xon_offset": "0",
-            "dynamic_th":"-6"
+            "dynamic_th":"0"
         },
         "egress_lossless_profile": {
             "pool":"ingress_lossless_pool",

--- a/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C72/1/buffers_defaults_t2.j2
+++ b/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-C72/1/buffers_defaults_t2.j2
@@ -30,7 +30,7 @@
             "pool":"ingress_lossless_pool",
             "size":"0",
 	    "xon_offset": "0",
-            "dynamic_th":"-6"
+            "dynamic_th":"0"
         },
         "egress_lossless_profile": {
             "pool":"ingress_lossless_pool",

--- a/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-D36/0/buffers_defaults_t2.j2
+++ b/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-D36/0/buffers_defaults_t2.j2
@@ -30,7 +30,7 @@
             "pool":"ingress_lossless_pool",
             "size":"0",
 	    "xon_offset": "0",
-            "dynamic_th":"-5"
+            "dynamic_th":"0"
         },
         "egress_lossless_profile": {
             "pool":"ingress_lossless_pool",

--- a/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-D36/1/buffers_defaults_t2.j2
+++ b/device/arista/x86_64-arista_7800r3a_36d2_lc/Arista-7800R3A-36D2-D36/1/buffers_defaults_t2.j2
@@ -30,7 +30,7 @@
             "pool":"ingress_lossless_pool",
             "size":"0",
 	    "xon_offset": "0",
-            "dynamic_th":"-5"
+            "dynamic_th":"0"
         },
         "egress_lossless_profile": {
             "pool":"ingress_lossless_pool",

--- a/device/nokia/x86_64-nokia_ixr7250e_36x400g-r0/Nokia-IXR7250E-36x100G/0/buffers_defaults_t2.j2
+++ b/device/nokia/x86_64-nokia_ixr7250e_36x400g-r0/Nokia-IXR7250E-36x100G/0/buffers_defaults_t2.j2
@@ -30,7 +30,7 @@
             "pool":"ingress_lossless_pool",
             "size":"0",
 	    "xon_offset": "0",
-            "dynamic_th":"-6"
+            "dynamic_th":"0"
         },
         "egress_lossless_profile": {
             "pool":"ingress_lossless_pool",

--- a/device/nokia/x86_64-nokia_ixr7250e_36x400g-r0/Nokia-IXR7250E-36x100G/1/buffers_defaults_t2.j2
+++ b/device/nokia/x86_64-nokia_ixr7250e_36x400g-r0/Nokia-IXR7250E-36x100G/1/buffers_defaults_t2.j2
@@ -30,7 +30,7 @@
             "pool":"ingress_lossless_pool",
             "size":"0",
 	    "xon_offset": "0",
-            "dynamic_th":"-6"
+            "dynamic_th":"0"
         },
         "egress_lossless_profile": {
             "pool":"ingress_lossless_pool",

--- a/device/nokia/x86_64-nokia_ixr7250e_36x400g-r0/Nokia-IXR7250E-36x400G/0/buffers_defaults_t2.j2
+++ b/device/nokia/x86_64-nokia_ixr7250e_36x400g-r0/Nokia-IXR7250E-36x400G/0/buffers_defaults_t2.j2
@@ -30,7 +30,7 @@
             "pool":"ingress_lossless_pool",
             "size":"0",
 	    "xon_offset": "0",
-            "dynamic_th":"-5"
+            "dynamic_th":"0"
         },
         "egress_lossless_profile": {
             "pool":"ingress_lossless_pool",

--- a/device/nokia/x86_64-nokia_ixr7250e_36x400g-r0/Nokia-IXR7250E-36x400G/1/buffers_defaults_t2.j2
+++ b/device/nokia/x86_64-nokia_ixr7250e_36x400g-r0/Nokia-IXR7250E-36x400G/1/buffers_defaults_t2.j2
@@ -30,7 +30,7 @@
             "pool":"ingress_lossless_pool",
             "size":"0",
 	    "xon_offset": "0",
-            "dynamic_th":"-5"
+            "dynamic_th":"0"
         },
         "egress_lossless_profile": {
             "pool":"ingress_lossless_pool",

--- a/src/sonic-config-engine/tests/sample_output/py2/buffer-arista7800r3-48cq2-lc.json
+++ b/src/sonic-config-engine/tests/sample_output/py2/buffer-arista7800r3-48cq2-lc.json
@@ -65,7 +65,7 @@
             "pool":"ingress_lossless_pool",
             "size":"0",
             "xon_offset":"0",
-            "dynamic_th":"-6"
+            "dynamic_th":"0"
         },
         "egress_lossless_profile": {
             "pool":"ingress_lossless_pool",

--- a/src/sonic-config-engine/tests/sample_output/py2/buffer-arista7800r3-48cqm2-lc.json
+++ b/src/sonic-config-engine/tests/sample_output/py2/buffer-arista7800r3-48cqm2-lc.json
@@ -65,7 +65,7 @@
             "pool":"ingress_lossless_pool",
             "size":"0",
             "xon_offset":"0",
-            "dynamic_th":"-6"
+            "dynamic_th":"0"
         },
         "egress_lossless_profile": {
             "pool":"ingress_lossless_pool",

--- a/src/sonic-config-engine/tests/sample_output/py2/buffer-arista7800r3a-36dm2-c36-lc.json
+++ b/src/sonic-config-engine/tests/sample_output/py2/buffer-arista7800r3a-36dm2-c36-lc.json
@@ -35,7 +35,7 @@
             "pool":"ingress_lossless_pool",
             "size":"0",
 	    "xon_offset": "0",
-            "dynamic_th":"-6"
+            "dynamic_th":"0"
         },
         "egress_lossless_profile": {
             "pool":"ingress_lossless_pool",

--- a/src/sonic-config-engine/tests/sample_output/py2/buffer-arista7800r3a-36dm2-d36-lc.json
+++ b/src/sonic-config-engine/tests/sample_output/py2/buffer-arista7800r3a-36dm2-d36-lc.json
@@ -35,7 +35,7 @@
             "pool":"ingress_lossless_pool",
             "size":"0",
 	    "xon_offset": "0",
-            "dynamic_th":"-5"
+            "dynamic_th":"0"
         },
         "egress_lossless_profile": {
             "pool":"ingress_lossless_pool",

--- a/src/sonic-config-engine/tests/sample_output/py2/buffer-nokia-ixr7250e-36x100g.json
+++ b/src/sonic-config-engine/tests/sample_output/py2/buffer-nokia-ixr7250e-36x100g.json
@@ -35,7 +35,7 @@
             "pool":"ingress_lossless_pool",
             "size":"0",
 	    "xon_offset": "0",
-            "dynamic_th":"-6"
+            "dynamic_th":"0"
         },
         "egress_lossless_profile": {
             "pool":"ingress_lossless_pool",

--- a/src/sonic-config-engine/tests/sample_output/py2/buffer-nokia-ixr7250e-36x400g.json
+++ b/src/sonic-config-engine/tests/sample_output/py2/buffer-nokia-ixr7250e-36x400g.json
@@ -35,7 +35,7 @@
             "pool":"ingress_lossless_pool",
             "size":"0",
 	    "xon_offset": "0",
-            "dynamic_th":"-5"
+            "dynamic_th":"0"
         },
         "egress_lossless_profile": {
             "pool":"ingress_lossless_pool",

--- a/src/sonic-config-engine/tests/sample_output/py3/buffer-arista7800r3-48cq2-lc.json
+++ b/src/sonic-config-engine/tests/sample_output/py3/buffer-arista7800r3-48cq2-lc.json
@@ -65,7 +65,7 @@
             "pool":"ingress_lossless_pool",
             "size":"0",
             "xon_offset":"0",
-            "dynamic_th":"-6"
+            "dynamic_th":"0"
         },
         "egress_lossless_profile": {
             "pool":"ingress_lossless_pool",

--- a/src/sonic-config-engine/tests/sample_output/py3/buffer-arista7800r3-48cqm2-lc.json
+++ b/src/sonic-config-engine/tests/sample_output/py3/buffer-arista7800r3-48cqm2-lc.json
@@ -65,7 +65,7 @@
             "pool":"ingress_lossless_pool",
             "size":"0",
             "xon_offset":"0",
-            "dynamic_th":"-6"
+            "dynamic_th":"0"
         },
         "egress_lossless_profile": {
             "pool":"ingress_lossless_pool",

--- a/src/sonic-config-engine/tests/sample_output/py3/buffer-arista7800r3a-36dm2-c36-lc.json
+++ b/src/sonic-config-engine/tests/sample_output/py3/buffer-arista7800r3a-36dm2-c36-lc.json
@@ -35,7 +35,7 @@
             "pool":"ingress_lossless_pool",
             "size":"0",
 	    "xon_offset": "0",
-            "dynamic_th":"-6"
+            "dynamic_th":"0"
         },
         "egress_lossless_profile": {
             "pool":"ingress_lossless_pool",

--- a/src/sonic-config-engine/tests/sample_output/py3/buffer-arista7800r3a-36dm2-d36-lc.json
+++ b/src/sonic-config-engine/tests/sample_output/py3/buffer-arista7800r3a-36dm2-d36-lc.json
@@ -35,7 +35,7 @@
             "pool":"ingress_lossless_pool",
             "size":"0",
 	    "xon_offset": "0",
-            "dynamic_th":"-5"
+            "dynamic_th":"0"
         },
         "egress_lossless_profile": {
             "pool":"ingress_lossless_pool",

--- a/src/sonic-config-engine/tests/sample_output/py3/buffer-nokia-ixr7250e-36x100g.json
+++ b/src/sonic-config-engine/tests/sample_output/py3/buffer-nokia-ixr7250e-36x100g.json
@@ -35,7 +35,7 @@
             "pool":"ingress_lossless_pool",
             "size":"0",
 	    "xon_offset": "0",
-            "dynamic_th":"-6"
+            "dynamic_th":"0"
         },
         "egress_lossless_profile": {
             "pool":"ingress_lossless_pool",

--- a/src/sonic-config-engine/tests/sample_output/py3/buffer-nokia-ixr7250e-36x400g.json
+++ b/src/sonic-config-engine/tests/sample_output/py3/buffer-nokia-ixr7250e-36x400g.json
@@ -35,7 +35,7 @@
             "pool":"ingress_lossless_pool",
             "size":"0",
 	    "xon_offset": "0",
-            "dynamic_th":"-5"
+            "dynamic_th":"0"
         },
         "egress_lossless_profile": {
             "pool":"ingress_lossless_pool",


### PR DESCRIPTION
…is (#19653)

Updated lossy PG threshold to be higher than Queue threshold not to allow PFC generation.

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

