### PR TITLE
Use bookworm macsec container for 2205.

### DIFF
--- a/dockers/docker-macsec/Dockerfile.j2
+++ b/dockers/docker-macsec/Dockerfile.j2
@@ -1,3 +1,11 @@
+{% set use_bookworm_macsec_container = true %}
+
+{% if use_bookworm_macsec_container -%}
+FROM publicmirror.azurecr.io/docker-macsec:202405
+RUN mkdir /etc/fips && echo 1 > /etc/fips/fips_enable
+COPY ["cli", "/cli/"]
+ENTRYPOINT ["/usr/local/bin/supervisord"]
+{% else %}
 {% from "dockers/dockerfile-macros.j2" import install_debian_packages, install_python_wheels, copy_files, cleanup_apt_and_python_cache %}
 FROM docker-config-engine-bullseye-{{DOCKER_USERNAME}}:{{DOCKER_USERTAG}}
 
@@ -27,3 +35,5 @@ COPY ["etc/wpa_supplicant.conf", "/etc/wpa_supplicant.conf"]
 COPY ["cli", "/cli/"]
 
 ENTRYPOINT ["/usr/local/bin/supervisord"]
+
+{%- endif %}


### PR DESCRIPTION
#### Why I did it
It's required that sonic 202205 to use bookworm macsec container. The reason is to utilize 202405 macsec container which uses symcrypt with provider + engine support for openssl so when 202405 macsec (hardware + macsec control plane) is FIPS certified we can declare that chassis deploying sonic 202205 is FIPS complaint with its macsec solution. 

Another requirement is to have macsec container runs in FIPS mode always.

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
1) Have macsec bookworm container available on public docker repo: publicmirror.azurecr.io. This bookworm container was taking from 202405 daily build repository.
2) Override /etc/fips/fips_enable to have value 1 during docker image build. 
3) It's found that the cli plugins in bookworm container has slight issue to work under 202205. For example, sonic-clear macsec does not work. Solution is to copy all cli plugin scripts to docker using the 202205 cli scripts. 

#### How to verify it
Few tests have been run to verify it works. 
1) Sonic OC macsec test suite has been run against the modified image. All tests passed. 
2) Static macsec test (chassis ---- axia ) with 400G port with PN unchanged. Test run overnight. No issue. 
3) Dynamic macsec test (chassis ---- chassis) with 400G port. Test run overnight. No issue. 

#### Which release branch to backport (provide reason below if selected)

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Tested branch (Please provide the tested image version)



