### PR TITLE
Cherry pick: [Nokia][snmpwalk] Fix the snmpwalk cefcFruPowerStatusTable on Nokia LC platform #19733

### DIFF
--- a/device/nokia/x86_64-nokia_ixr7250e_36x400g-r0/pmon_daemon_control.json
+++ b/device/nokia/x86_64-nokia_ixr7250e_36x400g-r0/pmon_daemon_control.json
@@ -1,3 +1,2 @@
 {
-    "skip_psud": true
 }


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Cherry-pick  PR https://github.com/sonic-net/sonic-buildimage/pull/19733 to MSFT Repo 202205 branch

This PR will enable to Psud in LC to address this issue. Fixes https://github.com/sonic-net/sonic-buildimage/issues/19535

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
Cherry-pick  PR https://github.com/sonic-net/sonic-buildimage/pull/19733 to MSFT Repo 202205 branch.  

Based on the snmp_agent common handling, it requires to enable the Pusd on the LC to set the "psu_num": 0 (as in the below entry) to allow the mibwalk handle the return value correctly. Enable the Psud on the LC although there is no PSU in LC.  

#### How to verify it
1. Executes "docker exec -it snmp snmpwalk -v2c -c 127.0.0.1 1.3.6.1.4.1.9.9.117.1.1.2.1"
2. Check the syslog, there should not any error in the syslog which is related to this MIBwalk.

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

