### PR TITLE
[VOQ Chassis] Reduce the i-BGP Keep alive and Hold timer value (#20189)

### DIFF
--- a/dockers/docker-fpm-frr/frr/bgpd/templates/voq_chassis/instance.conf.j2
+++ b/dockers/docker-fpm-frr/frr/bgpd/templates/voq_chassis/instance.conf.j2
@@ -11,7 +11,7 @@
 {% endif %}
   neighbor {{ neighbor_addr }} remote-as {{ bgp_session['asn'] }}
   neighbor {{ neighbor_addr }} description {{ bgp_session['name'] }}
-  neighbor {{ neighbor_addr }} timers 3 10
+  neighbor {{ neighbor_addr }} timers 2 7
   neighbor {{ neighbor_addr }} timers connect 10
 !
 {% if 'admin_status' in bgp_session and bgp_session['admin_status'] == 'down' or 'admin_status' not in bgp_session and 'default_bgp_status' in CONFIG_DB__DEVICE_METADATA['localhost'] and CONFIG_DB__DEVICE_METADATA['localhost']['default_bgp_status'] == 'down' %}

--- a/src/sonic-bgpcfgd/tests/data/voq_chassis/instance.conf/result_all_v4.conf
+++ b/src/sonic-bgpcfgd/tests/data/voq_chassis/instance.conf/result_all_v4.conf
@@ -7,7 +7,7 @@
   neighbor 10.10.10.10 peer-group VOQ_CHASSIS_V4_PEER
   neighbor 10.10.10.10 remote-as 555
   neighbor 10.10.10.10 description internal1
-  neighbor 10.10.10.10 timers 3 10
+  neighbor 10.10.10.10 timers 2 7
   neighbor 10.10.10.10 timers connect 10
   neighbor 10.10.10.10 shutdown
 !

--- a/src/sonic-bgpcfgd/tests/data/voq_chassis/instance.conf/result_all_v6.conf
+++ b/src/sonic-bgpcfgd/tests/data/voq_chassis/instance.conf/result_all_v6.conf
@@ -7,7 +7,7 @@
   neighbor fc00::01 peer-group VOQ_CHASSIS_V6_PEER
   neighbor fc00::01 remote-as 555
   neighbor fc00::01 description internal1
-  neighbor fc00::01 timers 3 10
+  neighbor fc00::01 timers 2 7
   neighbor fc00::01 timers connect 10
   neighbor fc00::01 shutdown
 !

--- a/src/sonic-bgpcfgd/tests/data/voq_chassis/instance.conf/result_base_v4.conf
+++ b/src/sonic-bgpcfgd/tests/data/voq_chassis/instance.conf/result_base_v4.conf
@@ -7,7 +7,7 @@
   neighbor 10.10.10.10 peer-group VOQ_CHASSIS_V4_PEER
   neighbor 10.10.10.10 remote-as 555
   neighbor 10.10.10.10 description internal1
-  neighbor 10.10.10.10 timers 3 10
+  neighbor 10.10.10.10 timers 2 7
   neighbor 10.10.10.10 timers connect 10
   address-family ipv4
     maximum-paths ibgp 64

--- a/src/sonic-bgpcfgd/tests/data/voq_chassis/instance.conf/result_base_v6.conf
+++ b/src/sonic-bgpcfgd/tests/data/voq_chassis/instance.conf/result_base_v6.conf
@@ -7,7 +7,7 @@
   neighbor fc00::01 peer-group VOQ_CHASSIS_V6_PEER
   neighbor fc00::01 remote-as 555
   neighbor fc00::01 description internal1
-  neighbor fc00::01 timers 3 10
+  neighbor fc00::01 timers 2 7
   neighbor fc00::01 timers connect 10
   address-family ipv4
     maximum-paths ibgp 64

--- a/src/sonic-bgpcfgd/tests/data/voq_chassis/instance.conf/result_shutdown_v4_1.conf
+++ b/src/sonic-bgpcfgd/tests/data/voq_chassis/instance.conf/result_shutdown_v4_1.conf
@@ -7,7 +7,7 @@
   neighbor 10.10.10.10 peer-group VOQ_CHASSIS_V4_PEER
   neighbor 10.10.10.10 remote-as 555
   neighbor 10.10.10.10 description internal1
-  neighbor 10.10.10.10 timers 3 10
+  neighbor 10.10.10.10 timers 2 7
   neighbor 10.10.10.10 timers connect 10
   neighbor 10.10.10.10 shutdown
 !

--- a/src/sonic-bgpcfgd/tests/data/voq_chassis/instance.conf/result_shutdown_v4_2.conf
+++ b/src/sonic-bgpcfgd/tests/data/voq_chassis/instance.conf/result_shutdown_v4_2.conf
@@ -7,7 +7,7 @@
   neighbor 10.10.10.10 peer-group VOQ_CHASSIS_V4_PEER
   neighbor 10.10.10.10 remote-as 555
   neighbor 10.10.10.10 description internal1
-  neighbor 10.10.10.10 timers 3 10
+  neighbor 10.10.10.10 timers 2 7
   neighbor 10.10.10.10 timers connect 10
   address-family ipv4
     maximum-paths ibgp 64

--- a/src/sonic-bgpcfgd/tests/data/voq_chassis/instance.conf/result_shutdown_v6_1.conf
+++ b/src/sonic-bgpcfgd/tests/data/voq_chassis/instance.conf/result_shutdown_v6_1.conf
@@ -7,7 +7,7 @@
   neighbor fc00::01 peer-group VOQ_CHASSIS_V6_PEER
   neighbor fc00::01 remote-as 555
   neighbor fc00::01 description internal1
-  neighbor fc00::01 timers 3 10
+  neighbor fc00::01 timers 2 7
   neighbor fc00::01 timers connect 10
   neighbor fc00::01 shutdown
 !

--- a/src/sonic-bgpcfgd/tests/data/voq_chassis/instance.conf/result_shutdown_v6_2.conf
+++ b/src/sonic-bgpcfgd/tests/data/voq_chassis/instance.conf/result_shutdown_v6_2.conf
@@ -7,7 +7,7 @@
   neighbor fc00::01 peer-group VOQ_CHASSIS_V6_PEER
   neighbor fc00::01 remote-as 555
   neighbor fc00::01 description internal1
-  neighbor fc00::01 timers 3 10
+  neighbor fc00::01 timers 2 7
   neighbor fc00::01 timers connect 10
   address-family ipv4
     maximum-paths ibgp 64

--- a/src/sonic-bgpcfgd/tests/data/voq_chassis/instance.conf/result_timers_v4_1.conf
+++ b/src/sonic-bgpcfgd/tests/data/voq_chassis/instance.conf/result_timers_v4_1.conf
@@ -7,7 +7,7 @@
   neighbor 10.10.10.10 peer-group VOQ_CHASSIS_V4_PEER
   neighbor 10.10.10.10 remote-as 555
   neighbor 10.10.10.10 description internal1
-  neighbor 10.10.10.10 timers 3 10
+  neighbor 10.10.10.10 timers 2 7
   neighbor 10.10.10.10 timers connect 10
   address-family ipv4
     maximum-paths ibgp 64

--- a/src/sonic-bgpcfgd/tests/data/voq_chassis/instance.conf/result_timers_v4_2.conf
+++ b/src/sonic-bgpcfgd/tests/data/voq_chassis/instance.conf/result_timers_v4_2.conf
@@ -7,7 +7,7 @@
   neighbor 10.10.10.10 peer-group VOQ_CHASSIS_V4_PEER
   neighbor 10.10.10.10 remote-as 555
   neighbor 10.10.10.10 description internal1
-  neighbor 10.10.10.10 timers 3 10
+  neighbor 10.10.10.10 timers 2 7
   neighbor 10.10.10.10 timers connect 10
   address-family ipv4
     maximum-paths ibgp 64

--- a/src/sonic-bgpcfgd/tests/data/voq_chassis/instance.conf/result_timers_v6_1.conf
+++ b/src/sonic-bgpcfgd/tests/data/voq_chassis/instance.conf/result_timers_v6_1.conf
@@ -7,7 +7,7 @@
   neighbor fc00::01 peer-group VOQ_CHASSIS_V6_PEER
   neighbor fc00::01 remote-as 555
   neighbor fc00::01 description internal1
-  neighbor fc00::01 timers 3 10
+  neighbor fc00::01 timers 2 7
   neighbor fc00::01 timers connect 10
   address-family ipv4
     maximum-paths ibgp 64

--- a/src/sonic-bgpcfgd/tests/data/voq_chassis/instance.conf/result_timers_v6_2.conf
+++ b/src/sonic-bgpcfgd/tests/data/voq_chassis/instance.conf/result_timers_v6_2.conf
@@ -7,7 +7,7 @@
   neighbor fc00::01 peer-group VOQ_CHASSIS_V6_PEER
   neighbor fc00::01 remote-as 555
   neighbor fc00::01 description internal1
-  neighbor fc00::01 timers 3 10
+  neighbor fc00::01 timers 2 7
   neighbor fc00::01 timers connect 10
   address-family ipv4
     maximum-paths ibgp 64


### PR DESCRIPTION
This is the cherry-pick PR for PR: https://github.com/sonic-net/sonic-buildimage/pull/20189

* Change the Hold timer to 7 sec and Keep alive to 2 sec for i-BGP session in VOQ Chassis

<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

