### PR TITLE
[Build] Fix docker-macsec-dbg build failure

### DIFF
--- a/build_debug_docker_j2.sh
+++ b/build_debug_docker_j2.sh
@@ -1,5 +1,11 @@
 #! /bin/bash
 
+# Workaround to fix build docker-macsec-dbg issue
+if [[ $1 == docker-macsec* ]]; then
+    cat dockers/docker-macsec/Dockerfile-debug.j2
+    exit 0
+fi
+
 echo "
 FROM $1
 

--- a/dockers/docker-macsec/Dockerfile-debug.j2
+++ b/dockers/docker-macsec/Dockerfile-debug.j2
@@ -1,0 +1,6 @@
+FROM publicmirror.azurecr.io/docker-macsec-dbg:202405
+
+RUN mkdir /etc/fips && echo 1 > /etc/fips/fips_enable
+COPY ["cli", "/cli/"]
+
+ENTRYPOINT ["/usr/local/bin/supervisord"]


### PR DESCRIPTION
<!--
     Please make sure you've read and understood our contributing guidelines:
     https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

     ** Make sure all your commits include a signature generated with `git commit -s` **

     If this is a bug fix, make sure your description includes "fixes #xxxx", or
     "closes #xxxx" or "resolves #xxxx"

     Please provide the following information:
-->

#### Why I did it
Fix docker-macsec-dbg build failure
```
Unpacking libteamdctl0:amd64 (1.30-1) over (1.31-1) ...
Preparing to unpack .../python3-swsscommon_1.0.0_amd64.deb ...
Unpacking python3-swsscommon (1.0.0) over (1.0.0) ...
Preparing to unpack debs/swss_1.0.0_amd64.deb ...
Unpacking swss (1.0.0) over (1.0.0) ...
Selecting previously unselected package libswsscommon-dbgsym.
Preparing to unpack .../libswsscommon-dbgsym_1.0.0_amd64.deb ...
Unpacking libswsscommon-dbgsym (1.0.0) ...
Selecting previously unselected package libhiredis0.14-dbgsym:amd64.
Preparing to unpack .../libhiredis0.14-dbgsym_0.14.1-1_amd64.deb ...
Unpacking libhiredis0.14-dbgsym:amd64 (0.14.1-1) ...
Selecting previously unselected package swss-dbg.
Preparing to unpack debs/swss-dbg_1.0.0_amd64.deb ...
Unpacking swss-dbg (1.0.0) ...
Selecting previously unselected package wpasupplicant-dbgsym.
Preparing to unpack .../wpasupplicant-dbgsym_2.9.0-14_amd64.deb ...
Unpacking wpasupplicant-dbgsym (2:2.9.0-14) ...
Setting up libnl-3-200:amd64 (3.5.0-1) ...
Setting up libnl-route-3-200:amd64 (3.5.0-1) ...
Setting up libnl-genl-3-200:amd64 (3.5.0-1) ...
Setting up libnl-nf-3-200:amd64 (3.5.0-1) ...
Setting up libhiredis0.14:amd64 (0.14.1-1) ...
Setting up libnl-cli-3-200:amd64 (3.5.0-1) ...
Setting up libswsscommon (1.0.0) ...
Setting up libsairedis (1.0.0) ...
Setting up libsaimetadata (1.0.0) ...
Setting up libteam5:amd64 (1.30-1) ...
Setting up libteamdctl0:amd64 (1.30-1) ...
Setting up swss (1.0.0) ...
dpkg: dependency problems prevent configuration of python3-swsscommon:
 python3-swsscommon depends on libpython3.9 (>= 3.9.1); however:
  Package libpython3.9 is not installed.

dpkg: error processing package python3-swsscommon (--install):
 dependency problems - leaving unconfigured
Setting up libswsscommon-dbgsym (1.0.0) ...
Setting up libhiredis0.14-dbgsym:amd64 (0.14.1-1) ...
Setting up swss-dbg (1.0.0) ...
Setting up wpasupplicant-dbgsym (2:2.9.0-14) ...
Processing triggers for libc-bin (2.36-9+deb12u7) ...
Errors were encountered while processing:
 python3-swsscommon

```

##### Work item tracking
- Microsoft ADO **(number only)**:

#### How I did it
The docker-macsec-dbg should be built on publicmirror.azurecr.io/docker-macsec-dbg:202405
The image docker-macsec:lastest was copied from 202405 branch, see PR: https://github.com/sonic-net/sonic-buildimage-msft/pull/443/files. The current build does not have the debug packages from the image.

#### How to verify it

<!--
If PR needs to be backported, then the PR must be tested against the base branch and the earliest backport release branch and provide tested image version on these two branches. For example, if the PR is requested for master, 202211 and 202012, then the requester needs to provide test results on master and 202012.
-->

#### Which release branch to backport (provide reason below if selected)

<!--
- Note we only backport fixes to a release branch, *not* features!
- Please also provide a reason for the backporting below.
- e.g.
- [x] 202006
-->

- [ ] 201811
- [ ] 201911
- [ ] 202006
- [ ] 202012
- [ ] 202106
- [ ] 202111
- [ ] 202205
- [ ] 202211

#### Tested branch (Please provide the tested image version)

<!--
- Please provide tested image version
- e.g.
- [x] 20201231.100
-->

- [ ] <!-- image version 1 -->
- [ ] <!-- image version 2 -->

#### Description for the changelog
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

<!--
 Ensure to add label/tag for the feature raised. example - PR#2174 under sonic-utilities repo. where, Generic Config and Update feature has been labelled as GCU.
-->

#### Link to config_db schema for YANG module changes
<!--
Provide a link to config_db schema for the table for which YANG model
is defined
Link should point to correct section on https://github.com/Azure/sonic-buildimage/blob/master/src/sonic-yang-models/doc/Configuration.md
-->

#### A picture of a cute animal (not mandatory but encouraged)

